### PR TITLE
Update ssh ruby libraries dependency and OpenSSL 3 compatability

### DIFF
--- a/artifact_tools.gemspec
+++ b/artifact_tools.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'ed25519', '~> 1.3'
   s.add_dependency 'bcrypt_pbkdf', '~> 1.1'
-  s.add_dependency 'net-scp', '~> 3.0'
-  s.add_dependency 'net-ssh', '~> 6'
+  s.add_dependency 'net-scp', '>= 4.0.0pre', '< 5.0'
+  s.add_dependency 'net-ssh', '~> 7.0'
 
   s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rake', '~> 12.3'

--- a/artifact_tools.gemspec
+++ b/artifact_tools.gemspec
@@ -17,8 +17,10 @@ Gem::Specification.new do |s|
   s.executables << 'artifact_download' << 'artifact_upload'
   s.require_paths = ['lib']
 
-  s.add_dependency 'net-scp', '~> 2.0'
-  s.add_dependency 'net-ssh', '~> 5.2'
+  s.add_dependency 'ed25519', '~> 1.3'
+  s.add_dependency 'bcrypt_pbkdf', '~> 1.1'
+  s.add_dependency 'net-scp', '~> 3.0'
+  s.add_dependency 'net-ssh', '~> 6'
 
   s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rake', '~> 12.3'

--- a/lib/artifact_tools/version.rb
+++ b/lib/artifact_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ArtifactTools
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end


### PR DESCRIPTION
- Add support for OpenSSL 3.0
  - Fix error: `pkeys are immutable on OpenSSL 3.0 (OpenSSL::PKey::PKeyError)`
- Add ed25519 and bcrypt_pbkdf for ed25519 support of net-ssh